### PR TITLE
Add feature .info file path in settings

### DIFF
--- a/lib/coverage-lcov.coffee
+++ b/lib/coverage-lcov.coffee
@@ -81,6 +81,13 @@ findInfoFile = (filePath) ->
       return filename
     return null
 
+  filename = atom.config.get('lcov-info.filePath')
+  if filename isnt "" and fs.existsSync(filename)
+      return filename
+
+  if filename isnt ""
+    atom.notifications.addError("The .info file path is wrong")
+
   while filePath and filePath isnt path.dirname(filePath)
     filename = testInfo(filePath, 'coverage') or testInfo(filePath, '.coverage')
     return filename if filename
@@ -88,6 +95,7 @@ findInfoFile = (filePath) ->
     filePath = path.dirname(filePath)
 
   console.log 'LcovInfoView: No coverage/lcov.info file found for', filePath
+  atom.notifications.addError("No .info file found.")
   return
 
 mapInfo = (filePath, lcovData, cb) ->

--- a/lib/lcov-info.coffee
+++ b/lib/lcov-info.coffee
@@ -15,7 +15,7 @@ module.exports =
       default: 'Covered & Uncovered Lines'
       enum: ['Covered & Uncovered Lines', 'Uncovered Lines Only']
     filePath:
-      title: 'File path (optionnal)'
+      title: 'File path (optional)'
       description: 'The path to the location of the .info file'
       type: 'string'
       default: ''

--- a/lib/lcov-info.coffee
+++ b/lib/lcov-info.coffee
@@ -14,6 +14,11 @@ module.exports =
       type: 'string'
       default: 'Covered & Uncovered Lines'
       enum: ['Covered & Uncovered Lines', 'Uncovered Lines Only']
+    filePath:
+      title: 'File path (optionnal)'
+      description: 'The path to the location of the .info file'
+      type: 'string'
+      default: ''
 
   lcovInfoView: null
 


### PR DESCRIPTION
Add a field in the package settings to specify a .info file instead of using the auto .info file research. Avoid to have a /coverage folder in the tree.